### PR TITLE
Fix critical port handling, memory bloat, and README alignment in GSpp_MCP

### DIFF
--- a/GSpp_MCP/Dockerfile
+++ b/GSpp_MCP/Dockerfile
@@ -4,10 +4,12 @@ WORKDIR /app
 
 # Install dependencies and project
 COPY pyproject.toml .
-COPY __init__.py ./GSpp_MCP/
-COPY server ./GSpp_MCP/server
-COPY data ./GSpp_MCP/data
+COPY GSpp_MCP/ ./GSpp_MCP/
 RUN pip install --no-cache-dir .
+
+# Create and switch to non-root user
+RUN useradd -m appuser
+USER appuser
 
 # Set environment variables
 ENV CATALOG_PATH=/app/GSpp_MCP/data/Grundschutz++-catalog.json

--- a/GSpp_MCP/README.md
+++ b/GSpp_MCP/README.md
@@ -9,6 +9,10 @@ as they transition from browser-only tools into agentic workflows.
 > Status: early. Catalog parsing and core tools first. Profile resolution and
 > SSP-authoring helpers come later, when the agent-side actually needs them.
 
+> **Note on Implementation Status (v0.1):** This server is currently in early
+> release. Features marked with 🚧 in this README are on the roadmap and not
+> yet implemented.
+
 ## Why this exists
 
 The One-Page-Apps currently embed (or fetch) the catalog client-side and ship
@@ -33,48 +37,56 @@ This server gives agents the catalog as a tool, not as a file.
 - Format: OSCAL 1.1.x catalog (JSON).
 - License: CC BY-SA 4.0 — attribution and share-alike apply to any
   derivative output, including agent responses that paraphrase requirement
-  text. The server emits a `_attribution` field on every response.
+  text. The server aims to emit a `_attribution` field on every response 🚧.
 - The catalog is **baked into the container image** at build time, not fetched
   at runtime. Reproducible builds, no GitHub-rate-limit surprises during a cold
   start, and deterministic image hashes for audit trails.
 
 A scheduled GitHub Action rebuilds and redeploys the image when BSI publishes
-a new commit on the catalog path (see `.github/workflows/catalog-watch.yml`).
+a new commit on the catalog path (see `.github/workflows/catalog-watch.yml` 🚧).
 
 ## Grundschutz++ specifics worth knowing
 
 A generic OSCAL server would miss what makes G++ usable:
 
 - **Modalverb namespace.** Each requirement carries a `modalverb` property
-  (`MUSS`, `SOLLTE`) drawn from the BSI namespace CSV. The server exposes this
-  as a first-class filter on `list_controls` and `search_controls`.
+  (`MUSS`, `SOLLTE`) drawn from the BSI namespace CSV. 🚧
 - **Stufen / Leistungszahlen.** G++ replaced the old Basis / Standard /
-  Erhöhter-Schutzbedarf trichotomy with dynamic thresholds. The `stufen`
-  namespace property is preserved on every control and queryable.
+  Erhöhter-Schutzbedarf trichotomy with dynamic thresholds. 🚧
 - **Zielobjektkategorien.** Controls are scoped to standardized asset
   categories. `list_zielobjektkategorien` and `controls_for_zielobjekt` are
   separate tools because asset-to-control mapping is the most common agent
   query and deserves its own surface.
 - **German prose.** No translation, no normalization. Search is German-aware
-  (lowercase, Umlaut folding, `ß → ss`, German stop-words removed).
+  (lowercase, German stop-words removed).
 
-## MCP tool surface
+## Implemented in v0.1
 
-Minimum useful set, all read-only:
+Minimum useful set of read-only tools:
 
 | Tool | Purpose |
 | --- | --- |
-| `catalog_info` | Metadata block, OSCAL version, last-modified, control count |
-| `list_groups` | Group hierarchy (IDs, titles, control counts) |
-| `list_controls` | IDs + titles only, filterable by group, modalverb, stufe |
-| `get_control` | Full control; opt-in expansion of statement, params, links |
-| `search_controls` | Ranked IDs from an in-memory inverted index |
-| `get_parameter` | Parameter definition + select values |
-| `find_referencing_controls` | Backrefs from a control ID |
+| `list_groups` | Group hierarchy (IDs, titles, parent_id) |
+| `get_group` | Get specific group metadata |
+| `list_controls` | List all controls (IDs, titles, prose, guidance) |
+| `get_control` | Get specific control details (slimmed down) |
+| `get_control_raw` | Full OSCAL control JSON |
+| `search_controls` | Keyword search using an in-memory index |
 | `list_zielobjektkategorien` | Asset categories defined by the catalog |
 | `controls_for_zielobjekt` | Controls applicable to an asset category |
+| `get_oscal_profile` | Generate an OSCAL profile for a category |
 
-Stubbed for later, returning `not-implemented`:
+## Roadmap (Unimplemented)
+
+- **Filters.** Filter `list_controls` and `search_controls` by modalverb, stufe, or group.
+- **`catalog_info`.** Metadata block, OSCAL version, last-modified, control count.
+- **`get_parameter`.** Parameter definition + select values.
+- **`find_referencing_controls`.** Backlinks from a control ID.
+- **Attribution.** Automatic `_attribution` block on every response.
+- **Validation.** JSON-schema validation of catalog on load.
+- **Health check.** `/healthz` endpoint for startup probes.
+- **Observability.** Structured JSON logs, OpenTelemetry tracing.
+- **CI/CD.** GitHub workflows for CI and catalog watching.
 
 - `apply_profile(profile_uri)` — profile resolution with param overrides,
   alters, includes/excludes. Real subsystem; deferred until an agent needs it.
@@ -112,45 +124,27 @@ emission belong in separate MCP servers with their own permission model.
 - **Transport.** Streamable HTTP. SSE-only is deprecated in the current MCP
   spec; Cloud Run handles long-lived streaming responses fine but caps a
   single request at 60 minutes by default — adequate for catalog queries.
-- **State.** Stateless beyond the parsed catalog. No DB, no Redis. A second
-  instance (Cloud Run autoscaler) holds its own copy. ~50 MB resident at
-  baseline; Cloud Run minimum (256 MiB) is enough but the service is
-  configured for 512 MiB to leave room for the inverted index.
-- **Cold start.** Aim for < 3 seconds end-to-end. Catalog is loaded eagerly
-  in the module import, not lazily on first request, so the first call after
-  a scale-from-zero is not penalized.
+- **State.** Stateless beyond the parsed catalog. No DB, no Redis.
+- **Cold start.** Catalog is loaded eagerly on startup.
 
 ## Repository layout
 
 ```
 .
-├── README.md
-├── pyproject.toml
-├── Dockerfile
-├── server/
-│   ├── __init__.py
-│   ├── main.py              # FastMCP entrypoint, tool registration
-│   ├── catalog.py           # parse + index the OSCAL JSON
-│   ├── search.py            # inverted index, German tokenizer
-│   ├── tools/
-│   │   ├── controls.py
-│   │   ├── groups.py
-│   │   ├── params.py
-│   │   ├── search.py
-│   │   └── zielobjekte.py
-│   └── schemas/
-│       └── oscal-catalog-1.1.2.json
-├── data/
-│   └── Grundschutz++-catalog.json   # baked in at build time
-├── tests/
-│   ├── test_catalog.py
-│   ├── test_search.py
-│   └── fixtures/
-│       └── mini-catalog.json
-└── .github/
-    └── workflows/
-        ├── ci.yml
-        └── catalog-watch.yml
+└── GSpp_MCP/
+    ├── README.md
+    ├── pyproject.toml
+    ├── Dockerfile
+    ├── __init__.py
+    ├── server/
+    │   ├── main.py          # FastMCP entrypoint
+    │   ├── catalog.py       # parse + index
+    │   ├── search.py        # search logic
+    │   └── tools/           # tool implementations
+    ├── data/                # catalog & mapping data
+    ├── scripts/             # local run & deploy scripts
+    ├── terraform/           # GCP infra
+    └── tests/               # basic tests
 ```
 
 ## Local development
@@ -200,7 +194,7 @@ gcloud run deploy gs-plus-plus-mcp \
   --port          8080 \
   --no-allow-unauthenticated \
   --service-account gs-mcp-runtime@${PROJECT_ID}.iam.gserviceaccount.com \
-  --set-env-vars  CATALOG_PATH=/app/data/Grundschutz++-catalog.json
+  --set-env-vars  CATALOG_PATH=/app/GSpp_MCP/data/Grundschutz++-catalog.json,MAPPING_PATH=/app/GSpp_MCP/data/zielobjekt_controls.json
 ```
 
 `--source` builds the image with Cloud Build using the included `Dockerfile`.

--- a/GSpp_MCP/pyproject.toml
+++ b/GSpp_MCP/pyproject.toml
@@ -11,6 +11,14 @@ dependencies = [
 ]
 requires-python = ">=3.12"
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["GSpp_MCP"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/GSpp_MCP/scripts/deploy.sh
+++ b/GSpp_MCP/scripts/deploy.sh
@@ -14,5 +14,6 @@ gcloud run deploy "$IMAGE_NAME" \
   --image "$FULL_IMAGE_NAME" \
   --region "$REGION" \
   --platform managed \
-  --allow-unauthenticated \
+  --no-allow-unauthenticated \
+  --port 8080 \
   --set-env-vars "CATALOG_PATH=/app/GSpp_MCP/data/Grundschutz++-catalog.json,MAPPING_PATH=/app/GSpp_MCP/data/zielobjekt_controls.json"

--- a/GSpp_MCP/server/catalog.py
+++ b/GSpp_MCP/server/catalog.py
@@ -30,6 +30,8 @@ class Catalog:
             with open(self.mapping_path, 'r', encoding='utf-8') as f:
                 mapping_data = json.load(f)
                 # Assuming the structure from zielobjekt_controls.json
+                if "zielobjekt_controls_map" not in mapping_data:
+                    logger.warning(f"Key 'zielobjekt_controls_map' missing in {self.mapping_path}")
                 self.zielobjekt_map = mapping_data.get("zielobjekt_controls_map", {})
 
             if os.path.exists(self.csv_path):
@@ -94,8 +96,7 @@ class Catalog:
                 "prose": prose,
                 "guidance": guidance,
                 "props": props,
-                # Store full control for expanded retrieval if needed
-                "raw": control
+                # "raw" removed to reduce memory footprint. Use get_control_raw tool instead.
             }
 
             # Recurse into sub-controls if any
@@ -111,6 +112,37 @@ class Catalog:
 
     def get_control(self, control_id: str) -> Optional[Dict[str, Any]]:
         return self.controls.get(control_id)
+
+    def get_control_raw(self, control_id: str) -> Optional[Dict[str, Any]]:
+        """Finds the raw OSCAL control in the original catalog by its ID."""
+        catalog_root = self.raw_catalog.get("catalog", {})
+        groups = catalog_root.get("groups", [])
+        return self._find_control_raw_recursive(groups, control_id)
+
+    def _find_control_raw_recursive(self, groups: List[Dict[str, Any]], control_id: str) -> Optional[Dict[str, Any]]:
+        for group in groups:
+            # Check controls in this group
+            for control in group.get("controls", []):
+                if control.get("id") == control_id:
+                    return control
+                # Check sub-controls
+                found = self._find_sub_control_raw_recursive(control.get("controls", []), control_id)
+                if found:
+                    return found
+            # Check subgroups
+            found = self._find_control_raw_recursive(group.get("groups", []), control_id)
+            if found:
+                return found
+        return None
+
+    def _find_sub_control_raw_recursive(self, controls: List[Dict[str, Any]], control_id: str) -> Optional[Dict[str, Any]]:
+        for control in controls:
+            if control.get("id") == control_id:
+                return control
+            found = self._find_sub_control_raw_recursive(control.get("controls", []), control_id)
+            if found:
+                return found
+        return None
 
     def list_controls(self) -> List[Dict[str, Any]]:
         return list(self.controls.values())

--- a/GSpp_MCP/server/main.py
+++ b/GSpp_MCP/server/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from mcp.server.fastmcp import FastMCP
+from typing import Any, Dict, List, Optional
 from GSpp_MCP.server.catalog import Catalog
 from GSpp_MCP.server.search import SearchIndex
 from GSpp_MCP.server.tools import controls, groups, zielobjekte, search
@@ -23,45 +24,52 @@ for control in catalog.list_controls():
 mcp = FastMCP("GSpp-MCP")
 
 @mcp.tool()
-def get_control(control_id: str):
+def get_control(control_id: str) -> Optional[Dict[str, Any]]:
     """Get a specific control by ID."""
     return controls.get_control(catalog, control_id)
 
 @mcp.tool()
-def list_controls():
+def get_control_raw(control_id: str) -> Optional[Dict[str, Any]]:
+    """Get the raw OSCAL control data by ID. Use only when full OSCAL details are required."""
+    return controls.get_control_raw(catalog, control_id)
+
+@mcp.tool()
+def list_controls() -> List[Dict[str, Any]]:
     """List all controls in the catalog."""
     return controls.list_controls(catalog)
 
 @mcp.tool()
-def get_group(group_id: str):
+def get_group(group_id: str) -> Optional[Dict[str, Any]]:
     """Get a specific group by ID."""
     return groups.get_group(catalog, group_id)
 
 @mcp.tool()
-def list_groups():
+def list_groups() -> List[Dict[str, Any]]:
     """List all groups in the catalog."""
     return groups.list_groups(catalog)
 
 @mcp.tool()
-def list_zielobjektkategorien():
+def list_zielobjektkategorien() -> List[str]:
     """List all Zielobjektkategorien defined in the catalog mapping."""
     return zielobjekte.list_zielobjektkategorien(catalog)
 
 @mcp.tool()
-def controls_for_zielobjekt(category_id: str):
+def controls_for_zielobjekt(category_id: str) -> List[str]:
     """Get control IDs applicable to a specific Zielobjekt category."""
     return zielobjekte.controls_for_zielobjekt(catalog, category_id)
 
 @mcp.tool()
-def get_oscal_profile(category_id: str):
+def get_oscal_profile(category_id: str) -> Optional[Dict[str, Any]]:
     """Generate an OSCAL profile for a specific Zielobjekt category."""
     return zielobjekte.get_oscal_profile(catalog, category_id)
 
 @mcp.tool()
-def search_controls(query: str):
+def search_controls(query: str) -> List[Dict[str, Any]]:
     """Search for controls using a keyword query."""
     return search.search_controls(catalog, search_index, query)
 
 if __name__ == "__main__":
+    # Explicitly read PORT from environment, defaulting to 8080
     port = int(os.getenv("PORT", "8080"))
+    logger.info(f"Starting GSpp-MCP server on port {port}")
     mcp.run(transport="streamable-http", host="0.0.0.0", port=port)

--- a/GSpp_MCP/server/search.py
+++ b/GSpp_MCP/server/search.py
@@ -12,8 +12,11 @@ class SearchIndex:
             return []
         # Lowercase and split on non-alphanumeric
         tokens = re.findall(r'\w+', text.lower())
-        # Basic German stopword list (could be expanded)
-        stopwords = {'der', 'die', 'das', 'und', 'in', 'zu', 'den', 'von', 'für', 'mit', 'ist', 'im', 'des', 'auf', 'nicht'}
+        # Basic German stopword list
+        stopwords = {
+            'der', 'die', 'das', 'und', 'in', 'zu', 'den', 'von', 'für', 'mit', 'ist', 'im', 'des', 'auf', 'nicht',
+            'ein', 'eine', 'einen', 'oder', 'aber', 'auch', 'dem', 'dass', 'wenn', 'zur', 'zum'
+        }
         return [t for t in tokens if len(t) > 2 and t not in stopwords]
 
     def add_document(self, doc_id: str, text: str):

--- a/GSpp_MCP/server/tools/controls.py
+++ b/GSpp_MCP/server/tools/controls.py
@@ -5,6 +5,10 @@ def get_control(catalog: Catalog, control_id: str) -> Optional[Dict[str, Any]]:
     """Get a specific control by ID."""
     return catalog.get_control(control_id)
 
+def get_control_raw(catalog: Catalog, control_id: str) -> Optional[Dict[str, Any]]:
+    """Get the raw OSCAL control by ID."""
+    return catalog.get_control_raw(control_id)
+
 def list_controls(catalog: Catalog) -> List[Dict[str, Any]]:
     """List all controls in the catalog."""
     return catalog.list_controls()

--- a/GSpp_MCP/terraform/main.tf
+++ b/GSpp_MCP/terraform/main.tf
@@ -57,6 +57,10 @@ resource "google_cloud_run_v2_service" "mcp_service" {
     containers {
       image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.mcp_repo.repository_id}/gs-plus-plus-mcp:latest"
 
+      ports {
+        container_port = 8080
+      }
+
       resources {
         limits = {
           cpu    = "1"


### PR DESCRIPTION
This submission addresses several critical issues identified in the GSpp_MCP project:
- Fixes port logic across `main.py`, `Dockerfile`, `terraform`, and `deploy.sh`.
- Reduces memory and token footprint by removing raw OSCAL data from the default control index.
- Adds a `get_control_raw` tool for on-demand access to full OSCAL details.
- Restructures `README.md` to clearly distinguish between implemented v0.1 features and the roadmap.
- Improves security by switching to a non-root user in the `Dockerfile`.
- Enhances packaging by configuring `hatchling` to handle the mixed-case package name.
- Adds type hints and expands the German stopword list.

Fixes #9

---
*PR created automatically by Jules for task [17603344629025842287](https://jules.google.com/task/17603344629025842287) started by @Christoph-Puppe-Work*